### PR TITLE
Add PC box editing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ the result into a legit savegame. Currently, it can:
 * Create 'valid' Radical Red Pokemons. All of them
   were caught at Pallet Town, which makes them not
   100% legit.
+# Edit PC box Pokémon
+```
+python examples/edit_pc_box.py <input_save> <output_save> <box> <slot> <species_id>
+```
 # Running the export
 call export_mons.py
 ```

--- a/examples/edit_pc_box.py
+++ b/examples/edit_pc_box.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from rr_parser import RadicalRed
+import sys
+inp = Path(sys.argv[1])
+outp = Path(sys.argv[2])
+box = int(sys.argv[3])
+slot = int(sys.argv[4])
+species = int(sys.argv[5])
+game = RadicalRed(inp.read_bytes())
+pkm = game.game_save.pc.boxes[box].pokemon[slot]
+pkm.set_species(species)
+game.set_pc_pokemon(pkm, box, slot)
+outp.write_bytes(game.savegame)

--- a/rr_parser/functions.py
+++ b/rr_parser/functions.py
@@ -105,7 +105,9 @@ def item_rr_to_name(item_rr):
     return constants.rr._items.items_dict[str(item_rr)]
 
 import json
-with open('rr_parser\\constants\\rr\\_pokemon.json') as f:
+from pathlib import Path
+PKM_DB_PATH = Path(__file__).resolve().parent / "constants" / "rr" / "_pokemon.json"
+with open(PKM_DB_PATH) as f:
     PKM_DB = json.load(f)
 def pkm_set_to_text(pkm: Union[Pokemon, BoxPokemon], level:int = None):
     """Example Output:

--- a/rr_parser/game_saves.py
+++ b/rr_parser/game_saves.py
@@ -3,7 +3,7 @@ from typing import Optional
 from .abstracts import GameSave as ABCGameSave
 from .enums import GameType
 from .sections import Section, Team, TrainerInfo, PC
-from .pkms import Pokemon
+from .pkms import Pokemon, BoxPokemon
 from .pokedex import Pokedex
 
 
@@ -119,6 +119,12 @@ class GameSave(ABCGameSave):
 
     def set_pokemon(self, pkm: Pokemon, team_pos: int):
         self.team.set_pokemon(pkm, team_pos)
+        self.update_from_sub_data()
+        assert self.check_valid()
+        pass
+
+    def set_pc_pokemon(self, pkm: BoxPokemon, box: int, slot: int):
+        self.pc.set_pokemon(pkm, box, slot)
         self.update_from_sub_data()
         assert self.check_valid()
         pass

--- a/rr_parser/games.py
+++ b/rr_parser/games.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from .charsets import Gen3Charset
 from .enums import GameType
-from .pkms import Pokemon
+from .pkms import Pokemon, BoxPokemon
 from .abstracts import UpdatableData
 from .game_saves import GameSave
 
@@ -95,6 +95,18 @@ class Gen3(UpdatableData, Gen3Charset):
 
     def set_pokemon(self, pkm: "Pokemon", team_pos: int):
         self.game_save.set_pokemon(pkm, team_pos)
+        if self.active_game_save == 0:
+            self.game_save_a = self.game_save
+            pass
+        else:
+            self.game_save_b = self.game_save
+            pass
+        self.update_from_sub_data()
+        assert self.check_valid()
+        pass
+
+    def set_pc_pokemon(self, pkm: "BoxPokemon", box: int, slot: int):
+        self.game_save.set_pc_pokemon(pkm, box, slot)
         if self.active_game_save == 0:
             self.game_save_a = self.game_save
             pass

--- a/rr_parser/pkms.py
+++ b/rr_parser/pkms.py
@@ -860,16 +860,22 @@ class BoxPokemon(ABCPokemon):
         self.sub_data.attacks = Attacks(substruct_data[11:16], isBoxMon=True)
         self.sub_data._evs = EVs(substruct_data[16:22])
         self.sub_data.misc = Misc(substruct_data[22:30])
-        
+
 
     def check(self):
         raise NotImplementedError
-    
+
     def update_from_sub_data(self):
+        self.update_from_data()
+
+    def set_species(self, species: int):
+        d = bytearray(self._data)
+        d[0x1C:0x1E] = species.to_bytes(2, 'little')
+        self._data = bytes(d)
         self.update_from_data()
     
     @property
     def data(self):
         return self._data
-    
-__all__ = ["Pokemon", "DecryptedData"]
+
+__all__ = ["Pokemon", "DecryptedData", "BoxPokemon"]

--- a/rr_parser/sections.py
+++ b/rr_parser/sections.py
@@ -362,3 +362,17 @@ class PC(Section):
         self.boxes = []
 
         self.update_from_data()
+
+    def set_pokemon(self, pkm: BoxPokemon, box: int, slot: int):
+        o = 4 + box * PKM_PER_BOX * BYTES_PER_PKM + slot * BYTES_PER_PKM
+        d = bytearray(self._data)
+        d[o:o+BYTES_PER_PKM] = pkm.data
+        self._data = bytes(d)
+        s = 0
+        for sec_id in range(5, 14):
+            size = DATA_SIZES[sec_id]
+            sec = bytearray(self.game_save.sections[sec_id].section)
+            sec[0:size] = self._data[s:s+size]
+            self.game_save.sections[sec_id].section = bytes(sec)
+            s += size
+        self.update_from_data()


### PR DESCRIPTION
## Summary
- allow modifying PC box Pokémon by slot and box
- expose BoxPokemon species setter and PC editing helpers
- add script and documentation for editing PC boxes

## Testing
- `pytest -q` *(fails: AssertionError: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_688e699b484c8331be0cd9842a8ad46e